### PR TITLE
RFC: Improvements to codegen

### DIFF
--- a/hphp/runtime/base/tv-helpers.cpp
+++ b/hphp/runtime/base/tv-helpers.cpp
@@ -647,7 +647,7 @@ bool tvCanBeCoercedToNumber(TypedValue* tv) {
       // Because PHP
       auto str = tv->m_data.pstr;
       auto p = str->data();
-      auto l = tv->m_data.pstr->size();
+      unsigned long l = tv->m_data.pstr->size();
       while (l && isspace(*p)) { ++p; --l; }
       if (l && (*p == '+' || *p == '-')) { ++p; --l; }
       if (l && *p == '.') { ++p; --l; }

--- a/hphp/runtime/vm/jit/vasm-instr.h
+++ b/hphp/runtime/vm/jit/vasm-instr.h
@@ -893,6 +893,13 @@ struct divint { Vreg s0, s1, d; };
  * can do whatever they please with the upper bits.
  */
 
+enum Signs {
+  signedOnly,
+  unsignedOnly,
+  both,
+  neither
+};
+ 
 /*
  * Nop and trap.
  */
@@ -903,11 +910,11 @@ struct ud2 {};
  * Arithmetic instructions.
  */
 // add: s0 + {s1|m} => {d|m}, sf
-struct addl   { Vreg32 s0, s1, d; VregSF sf; bool needUnsigned; };
+struct addl   { Vreg32 s0, s1, d; VregSF sf; Signs signFlags; };
 struct addli  { Immed s0; Vreg32 s1, d; VregSF sf; };
 struct addlm  { Vreg32 s0; Vptr m; VregSF sf; };
 struct addlim { Immed s0; Vptr m; VregSF sf; };
-struct addq  { Vreg64 s0, s1, d; VregSF sf; bool needUnsigned; };
+struct addq  { Vreg64 s0, s1, d; VregSF sf; Signs signFlags; };
 struct addqi { Immed s0; Vreg64 s1, d; VregSF sf; };
 struct addqim { Immed s0; Vptr m; VregSF sf; };
 struct addsd  { VregDbl s0, s1, d; };
@@ -917,58 +924,58 @@ struct andbi { Immed s0; Vreg8 s1, d; VregSF sf; };
 struct andbim { Immed s; Vptr m; VregSF sf; };
 struct andl  { Vreg32 s0, s1, d; VregSF sf; };
 struct andli { Immed s0; Vreg32 s1, d; VregSF sf; };
-struct andq  { Vreg64 s0, s1, d; VregSF sf; bool needUnsigned; };
-struct andqi { Immed s0; Vreg64 s1, d; VregSF sf; bool needUnsigned; };
+struct andq  { Vreg64 s0, s1, d; VregSF sf; Signs signFlags; };
+struct andqi { Immed s0; Vreg64 s1, d; VregSF sf; Signs signFlags; };
 // dec: {s|m} - 1 => {d|m}, sf
-struct decl { Vreg32 s, d; VregSF sf; bool needUnsigned; };
+struct decl { Vreg32 s, d; VregSF sf; Signs signFlags; };
 struct declm { Vptr m; VregSF sf; };
-struct decq { Vreg64 s, d; VregSF sf; bool needUnsigned; };
+struct decq { Vreg64 s, d; VregSF sf; Signs signFlags; };
 struct decqm { Vptr m; VregSF sf; };
 struct decqmlock { Vptr m; VregSF sf; };
 // inc: {s|m} + 1 => {d|m}, sf
-struct incw { Vreg16 s, d; VregSF sf; bool needUnsigned; };
+struct incw { Vreg16 s, d; VregSF sf; Signs signFlags; };
 struct incwm { Vptr m; VregSF sf; };
-struct incl { Vreg32 s, d; VregSF sf; bool needUnsigned; };
+struct incl { Vreg32 s, d; VregSF sf; Signs signFlags; };
 struct inclm { Vptr m; VregSF sf; };
-struct incq { Vreg64 s, d; VregSF sf; bool needUnsigned; };
+struct incq { Vreg64 s, d; VregSF sf; Signs signFlags; };
 struct incqm { Vptr m; VregSF sf; };
 struct incqmlock { Vptr m; VregSF sf; };
 // mul: s0 * s1 => d, sf
-struct imul { Vreg64 s0, s1, d; VregSF sf; bool needUnsigned; };
+struct imul { Vreg64 s0, s1, d; VregSF sf; Signs signFlags; };
 // neg: 0 - s => d, sf
-struct neg { Vreg64 s, d; VregSF sf;  bool needUnsigned; };
+struct neg { Vreg64 s, d; VregSF sf;  Signs signFlags; };
 // not: ~s => d
 struct notb { Vreg8 s, d; };
 struct not { Vreg64 s, d; };
 // or: s0 | {s1|m} => {d|m}, sf
 struct orbim { Immed s0; Vptr m; VregSF sf; };
 struct orwim { Immed s0; Vptr m; VregSF sf; };
-struct orq { Vreg64 s0, s1, d; VregSF sf; bool needUnsigned; };
-struct orqi { Immed s0; Vreg64 s1, d; VregSF sf; bool needUnsigned; };
+struct orq { Vreg64 s0, s1, d; VregSF sf; Signs signFlags; };
+struct orqi { Immed s0; Vreg64 s1, d; VregSF sf; Signs signFlags; };
 struct orqim { Immed s0; Vptr m; VregSF sf; };
 // shift: s1 << s0 => d, sf
-struct sar { Vreg64 s0, s1, d; VregSF sf; bool needUnsigned; };
-struct shl { Vreg64 s0, s1, d; VregSF sf; bool needUnsigned; };
-struct sarqi { Immed s0; Vreg64 s1, d; VregSF sf; bool needUnsigned; };
-struct shlli { Immed s0; Vreg32 s1, d; VregSF sf; bool needUnsigned; };
-struct shlqi { Immed s0; Vreg64 s1, d; VregSF sf; bool needUnsigned; };
-struct shrli { Immed s0; Vreg32 s1, d; VregSF sf; bool needUnsigned; };
-struct shrqi { Immed s0; Vreg64 s1, d; VregSF sf; bool needUnsigned; };
+struct sar { Vreg64 s0, s1, d; VregSF sf; Signs signFlags; };
+struct shl { Vreg64 s0, s1, d; VregSF sf; Signs signFlags; };
+struct sarqi { Immed s0; Vreg64 s1, d; VregSF sf; Signs signFlags; };
+struct shlli { Immed s0; Vreg32 s1, d; VregSF sf; Signs signFlags; };
+struct shlqi { Immed s0; Vreg64 s1, d; VregSF sf; Signs signFlags; };
+struct shrli { Immed s0; Vreg32 s1, d; VregSF sf; Signs signFlags; };
+struct shrqi { Immed s0; Vreg64 s1, d; VregSF sf; Signs signFlags; };
 struct psllq { Immed s0; VregDbl s1, d; };
 struct psrlq { Immed s0; VregDbl s1, d; };
 // sub: s1 - s0 => d, sf
 struct subbi { Immed s0; Vreg8 s1, d; VregSF sf; };
 struct subl { Vreg32 s0, s1, d; VregSF sf; };
 struct subli { Immed s0; Vreg32 s1, d; VregSF sf; };
-struct subq { Vreg64 s0, s1, d; VregSF sf; bool needUnsigned; };
+struct subq { Vreg64 s0, s1, d; VregSF sf; Signs signFlags; };
 struct subqi { Immed s0; Vreg64 s1, d; VregSF sf; };
 struct subsd { VregDbl s0, s1, d; };
 // xor: s0 ^ s1 => d, sf
-struct xorb { Vreg8 s0, s1, d; VregSF sf; bool needUnsigned; };
+struct xorb { Vreg8 s0, s1, d; VregSF sf; Signs signFlags; };
 struct xorbi { Immed s0; Vreg8 s1, d; VregSF sf; };
-struct xorl { Vreg32 s0, s1, d; VregSF sf; bool needUnsigned; };
-struct xorq { Vreg64 s0, s1, d; VregSF sf; bool needUnsigned; };
-struct xorqi { Immed s0; Vreg64 s1, d; VregSF sf; bool needUnsigned; };
+struct xorl { Vreg32 s0, s1, d; VregSF sf; Signs signFlags; };
+struct xorq { Vreg64 s0, s1, d; VregSF sf; Signs signFlags; };
+struct xorqi { Immed s0; Vreg64 s1, d; VregSF sf; Signs signFlags; };
 
 /*
  * Compares and tests.
@@ -980,12 +987,12 @@ struct cmpbim { Immed s0; Vptr s1; VregSF sf; };
 struct cmpbm { Vreg8 s0; Vptr s1; VregSF sf; };
 struct cmpwim { Immed s0; Vptr s1; VregSF sf; };
 struct cmpwm { Vreg16 s0; Vptr s1; VregSF sf; };
-struct cmpl { Vreg32 s0; Vreg32 s1; VregSF sf; bool needUnsigned; };
-struct cmpli { Immed s0; Vreg32 s1; VregSF sf; bool needUnsigned; };
+struct cmpl { Vreg32 s0; Vreg32 s1; VregSF sf; Signs signFlags; };
+struct cmpli { Immed s0; Vreg32 s1; VregSF sf; Signs signFlags; };
 struct cmplm { Vreg32 s0; Vptr s1; VregSF sf; };
 struct cmplim { Immed s0; Vptr s1; VregSF sf; };
-struct cmpq { Vreg64 s0; Vreg64 s1; VregSF sf; bool needUnsigned; };
-struct cmpqi { Immed s0; Vreg64 s1; VregSF sf; bool needUnsigned; };
+struct cmpq { Vreg64 s0; Vreg64 s1; VregSF sf; Signs signFlags; };
+struct cmpqi { Immed s0; Vreg64 s1; VregSF sf; Signs signFlags; };
 struct cmpqm { Vreg64 s0; Vptr s1; VregSF sf; };
 struct cmpqim { Immed s0; Vptr s1; VregSF sf; };
 struct cmpsd { ComparisonPred pred; VregDbl s0, s1, d; };
@@ -998,7 +1005,7 @@ struct testwim { Immed s0; Vptr s1; VregSF sf; };
 struct testl { Vreg32 s0, s1; VregSF sf; };
 struct testli { Immed s0; Vreg32 s1; VregSF sf; };
 struct testlim { Immed s0; Vptr s1; VregSF sf; };
-struct testq { Vreg64 s0, s1; VregSF sf; bool needUnsigned; };
+struct testq { Vreg64 s0, s1; VregSF sf; Signs signFlags; };
 struct testqi { Immed s0; Vreg64 s1; VregSF sf; };
 struct testqm { Vreg64 s0; Vptr s1; VregSF sf; };
 struct testqim { Immed s0; Vptr s1; VregSF sf; };

--- a/hphp/runtime/vm/jit/vasm-instr.h
+++ b/hphp/runtime/vm/jit/vasm-instr.h
@@ -903,11 +903,11 @@ struct ud2 {};
  * Arithmetic instructions.
  */
 // add: s0 + {s1|m} => {d|m}, sf
-struct addl   { Vreg32 s0, s1, d; VregSF sf; };
+struct addl   { Vreg32 s0, s1, d; VregSF sf; bool needUnsigned; };
 struct addli  { Immed s0; Vreg32 s1, d; VregSF sf; };
 struct addlm  { Vreg32 s0; Vptr m; VregSF sf; };
 struct addlim { Immed s0; Vptr m; VregSF sf; };
-struct addq  { Vreg64 s0, s1, d; VregSF sf; };
+struct addq  { Vreg64 s0, s1, d; VregSF sf; bool needUnsigned; };
 struct addqi { Immed s0; Vreg64 s1, d; VregSF sf; };
 struct addqim { Immed s0; Vptr m; VregSF sf; };
 struct addsd  { VregDbl s0, s1, d; };
@@ -917,58 +917,58 @@ struct andbi { Immed s0; Vreg8 s1, d; VregSF sf; };
 struct andbim { Immed s; Vptr m; VregSF sf; };
 struct andl  { Vreg32 s0, s1, d; VregSF sf; };
 struct andli { Immed s0; Vreg32 s1, d; VregSF sf; };
-struct andq  { Vreg64 s0, s1, d; VregSF sf; };
-struct andqi { Immed s0; Vreg64 s1, d; VregSF sf; };
+struct andq  { Vreg64 s0, s1, d; VregSF sf; bool needUnsigned; };
+struct andqi { Immed s0; Vreg64 s1, d; VregSF sf; bool needUnsigned; };
 // dec: {s|m} - 1 => {d|m}, sf
-struct decl { Vreg32 s, d; VregSF sf; };
+struct decl { Vreg32 s, d; VregSF sf; bool needUnsigned; };
 struct declm { Vptr m; VregSF sf; };
-struct decq { Vreg64 s, d; VregSF sf; };
+struct decq { Vreg64 s, d; VregSF sf; bool needUnsigned; };
 struct decqm { Vptr m; VregSF sf; };
 struct decqmlock { Vptr m; VregSF sf; };
 // inc: {s|m} + 1 => {d|m}, sf
-struct incw { Vreg16 s, d; VregSF sf; };
+struct incw { Vreg16 s, d; VregSF sf; bool needUnsigned; };
 struct incwm { Vptr m; VregSF sf; };
-struct incl { Vreg32 s, d; VregSF sf; };
+struct incl { Vreg32 s, d; VregSF sf; bool needUnsigned; };
 struct inclm { Vptr m; VregSF sf; };
-struct incq { Vreg64 s, d; VregSF sf; };
+struct incq { Vreg64 s, d; VregSF sf; bool needUnsigned; };
 struct incqm { Vptr m; VregSF sf; };
 struct incqmlock { Vptr m; VregSF sf; };
 // mul: s0 * s1 => d, sf
-struct imul { Vreg64 s0, s1, d; VregSF sf; };
+struct imul { Vreg64 s0, s1, d; VregSF sf; bool needUnsigned; };
 // neg: 0 - s => d, sf
-struct neg { Vreg64 s, d; VregSF sf; };
+struct neg { Vreg64 s, d; VregSF sf;  bool needUnsigned; };
 // not: ~s => d
 struct notb { Vreg8 s, d; };
 struct not { Vreg64 s, d; };
 // or: s0 | {s1|m} => {d|m}, sf
 struct orbim { Immed s0; Vptr m; VregSF sf; };
 struct orwim { Immed s0; Vptr m; VregSF sf; };
-struct orq { Vreg64 s0, s1, d; VregSF sf; };
-struct orqi { Immed s0; Vreg64 s1, d; VregSF sf; };
+struct orq { Vreg64 s0, s1, d; VregSF sf; bool needUnsigned; };
+struct orqi { Immed s0; Vreg64 s1, d; VregSF sf; bool needUnsigned; };
 struct orqim { Immed s0; Vptr m; VregSF sf; };
 // shift: s1 << s0 => d, sf
-struct sar { Vreg64 s0, s1, d; VregSF sf; };
-struct shl { Vreg64 s0, s1, d; VregSF sf; };
-struct sarqi { Immed s0; Vreg64 s1, d; VregSF sf; };
-struct shlli { Immed s0; Vreg32 s1, d; VregSF sf; };
-struct shlqi { Immed s0; Vreg64 s1, d; VregSF sf; };
-struct shrli { Immed s0; Vreg32 s1, d; VregSF sf; };
-struct shrqi { Immed s0; Vreg64 s1, d; VregSF sf; };
+struct sar { Vreg64 s0, s1, d; VregSF sf; bool needUnsigned; };
+struct shl { Vreg64 s0, s1, d; VregSF sf; bool needUnsigned; };
+struct sarqi { Immed s0; Vreg64 s1, d; VregSF sf; bool needUnsigned; };
+struct shlli { Immed s0; Vreg32 s1, d; VregSF sf; bool needUnsigned; };
+struct shlqi { Immed s0; Vreg64 s1, d; VregSF sf; bool needUnsigned; };
+struct shrli { Immed s0; Vreg32 s1, d; VregSF sf; bool needUnsigned; };
+struct shrqi { Immed s0; Vreg64 s1, d; VregSF sf; bool needUnsigned; };
 struct psllq { Immed s0; VregDbl s1, d; };
 struct psrlq { Immed s0; VregDbl s1, d; };
 // sub: s1 - s0 => d, sf
 struct subbi { Immed s0; Vreg8 s1, d; VregSF sf; };
 struct subl { Vreg32 s0, s1, d; VregSF sf; };
 struct subli { Immed s0; Vreg32 s1, d; VregSF sf; };
-struct subq { Vreg64 s0, s1, d; VregSF sf; };
+struct subq { Vreg64 s0, s1, d; VregSF sf; bool needUnsigned; };
 struct subqi { Immed s0; Vreg64 s1, d; VregSF sf; };
 struct subsd { VregDbl s0, s1, d; };
 // xor: s0 ^ s1 => d, sf
-struct xorb { Vreg8 s0, s1, d; VregSF sf; };
+struct xorb { Vreg8 s0, s1, d; VregSF sf; bool needUnsigned; };
 struct xorbi { Immed s0; Vreg8 s1, d; VregSF sf; };
-struct xorl { Vreg32 s0, s1, d; VregSF sf; };
-struct xorq { Vreg64 s0, s1, d; VregSF sf; };
-struct xorqi { Immed s0; Vreg64 s1, d; VregSF sf; };
+struct xorl { Vreg32 s0, s1, d; VregSF sf; bool needUnsigned; };
+struct xorq { Vreg64 s0, s1, d; VregSF sf; bool needUnsigned; };
+struct xorqi { Immed s0; Vreg64 s1, d; VregSF sf; bool needUnsigned; };
 
 /*
  * Compares and tests.
@@ -980,12 +980,12 @@ struct cmpbim { Immed s0; Vptr s1; VregSF sf; };
 struct cmpbm { Vreg8 s0; Vptr s1; VregSF sf; };
 struct cmpwim { Immed s0; Vptr s1; VregSF sf; };
 struct cmpwm { Vreg16 s0; Vptr s1; VregSF sf; };
-struct cmpl { Vreg32 s0; Vreg32 s1; VregSF sf; };
-struct cmpli { Immed s0; Vreg32 s1; VregSF sf; };
+struct cmpl { Vreg32 s0; Vreg32 s1; VregSF sf; bool needUnsigned; };
+struct cmpli { Immed s0; Vreg32 s1; VregSF sf; bool needUnsigned; };
 struct cmplm { Vreg32 s0; Vptr s1; VregSF sf; };
 struct cmplim { Immed s0; Vptr s1; VregSF sf; };
-struct cmpq { Vreg64 s0; Vreg64 s1; VregSF sf; };
-struct cmpqi { Immed s0; Vreg64 s1; VregSF sf; };
+struct cmpq { Vreg64 s0; Vreg64 s1; VregSF sf; bool needUnsigned; };
+struct cmpqi { Immed s0; Vreg64 s1; VregSF sf; bool needUnsigned; };
 struct cmpqm { Vreg64 s0; Vptr s1; VregSF sf; };
 struct cmpqim { Immed s0; Vptr s1; VregSF sf; };
 struct cmpsd { ComparisonPred pred; VregDbl s0, s1, d; };
@@ -998,7 +998,7 @@ struct testwim { Immed s0; Vptr s1; VregSF sf; };
 struct testl { Vreg32 s0, s1; VregSF sf; };
 struct testli { Immed s0; Vreg32 s1; VregSF sf; };
 struct testlim { Immed s0; Vptr s1; VregSF sf; };
-struct testq { Vreg64 s0, s1; VregSF sf; };
+struct testq { Vreg64 s0, s1; VregSF sf; bool needUnsigned; };
 struct testqi { Immed s0; Vreg64 s1; VregSF sf; };
 struct testqm { Vreg64 s0; Vptr s1; VregSF sf; };
 struct testqim { Immed s0; Vptr s1; VregSF sf; };

--- a/hphp/runtime/vm/jit/vasm-ppc64.cpp
+++ b/hphp/runtime/vm/jit/vasm-ppc64.cpp
@@ -421,7 +421,7 @@ struct Vgen {
       copyCR0toCR1(a, rAsm);
     } else {
       a.cmpdi(i.s0, Immed(0));
-      a.cmpldi(i.s0, Immed(0));
+      a.cmpldi(i.s0, Immed(0), Assembler::CR::CR1);
     }
   }
   void emit(const xorqi& i) {

--- a/hphp/runtime/vm/jit/vasm-ppc64.cpp
+++ b/hphp/runtime/vm/jit/vasm-ppc64.cpp
@@ -154,7 +154,7 @@ struct Vgen {
   }
   void emit(const addl& i) {
     a.addo(Reg64(i.d), Reg64(i.s1), Reg64(i.s0), true);
-    if (i.needUnsigned)
+    if (i.signFlags == unsignedOnly || i.signFlags == both)
       copyCR0toCR1(a, rAsm);
   }
   void emit(const ldimmqs& i) {
@@ -169,52 +169,52 @@ struct Vgen {
   // instructions
   void emit(const addq& i) {
     a.addo(i.d, i.s0, i.s1, true);
-    if (i.needUnsigned) {
-      Logger::Verbose("addq emitting cr0-1");
+    if (i.signFlags == unsignedOnly || i.signFlags == both)
       copyCR0toCR1(a, rAsm);
-    } else {
-      Logger::Verbose("addq not emitting cr0-1");
-    }
   }
   void emit(const addsd& i) { a.fadd(i.d, i.s0, i.s1); }
   void emit(const andq& i) {
     a.and(i.d, i.s0, i.s1, true);
-    if (i.needUnsigned)
+    if (i.signFlags == unsignedOnly || i.signFlags == both)
       copyCR0toCR1(a, rAsm);
   }
   void emit(const andqi& i) {
     a.andi(i.d, i.s1, i.s0);
-    if (i.needUnsigned)
+    if (i.signFlags == unsignedOnly || i.signFlags == both)
       copyCR0toCR1(a, rAsm);
   } // andi changes CR0
   void emit(const cmpl& i) {
-    a.cmpw(Reg64(i.s1), Reg64(i.s0));
-    if (i.needUnsigned)
+    if (i.signFlags == signedOnly || i.signFlags == both)
+      a.cmpw(Reg64(i.s1), Reg64(i.s0));
+    if (i.signFlags == unsignedOnly || i.signFlags == both)
       a.cmplw(Reg64(i.s1), Reg64(i.s0), Assembler::CR::CR1);
   }
   void emit(const cmpli& i) {
-    a.cmpwi(Reg64(i.s1), i.s0);
-    if (i.needUnsigned)
+    if (i.signFlags == signedOnly || i.signFlags == both)
+      a.cmpwi(Reg64(i.s1), i.s0);
+    if (i.signFlags == unsignedOnly || i.signFlags == both)
       a.cmplwi(Reg64(i.s1), i.s0, Assembler::CR::CR1);
   }
   void emit(const cmpq& i) {
-    a.cmpd(i.s1, i.s0);
-    if (i.needUnsigned)
+    if (i.signFlags == signedOnly || i.signFlags == both)
+      a.cmpd(i.s1, i.s0);
+    if (i.signFlags == unsignedOnly || i.signFlags == both)
       a.cmpld(i.s1, i.s0, Assembler::CR::CR1);
   }
   void emit(const cmpqi& i) {
-    a.cmpdi(i.s1, i.s0);
-    if (i.needUnsigned)
+    if (i.signFlags == signedOnly || i.signFlags == both)
+      a.cmpdi(i.s1, i.s0);
+    if (i.signFlags == unsignedOnly || i.signFlags == both)
       a.cmpldi(i.s1, i.s0, Assembler::CR::CR1);
   }
   void emit(const decl& i) {
     a.subfo(Reg64(i.d), rone(), Reg64(i.s), true);
-    if (i.needUnsigned)
+    if (i.signFlags == unsignedOnly || i.signFlags == both)
       copyCR0toCR1(a, rAsm);
   }
   void emit(const decq& i) {
     a.subfo(i.d, rone(), i.s, true);
-    if (i.needUnsigned)
+    if (i.signFlags == unsignedOnly || i.signFlags == both)
       copyCR0toCR1(a, rAsm);
   }
   void emit(const divint& i) { a.divd(i.d,  i.s0, i.s1, false); }
@@ -230,7 +230,7 @@ struct Vgen {
   void emit(const fallthru& i) {}
   void emit(const fcmpo& i) {
     a.fcmpo(i.sf, i.s0, i.s1);
-    copyCR0toCR1(a, rAsm);
+    copyCR0toCR1(a, rAsm); //todo: guarding this broke 3 tests
   }
   void emit(const fcmpu& i) {
     a.fcmpu(i.sf, i.s0, i.s1);
@@ -238,22 +238,22 @@ struct Vgen {
   }
   void emit(const imul& i) {
     a.mulldo(i.d, i.s1, i.s0, true);
-    if (i.needUnsigned)
+    if (i.signFlags == unsignedOnly || i.signFlags == both)
       copyCR0toCR1(a, rAsm);
   }
   void emit(const incl& i) {
     a.addo(Reg64(i.d), Reg64(i.s), rone(), true);
-    if (i.needUnsigned)
+    if (i.signFlags == unsignedOnly || i.signFlags == both)
       copyCR0toCR1(a, rAsm);
   }
   void emit(const incq& i) {
     a.addo(i.d, i.s, rone(), true);
-    if (i.needUnsigned)
+    if (i.signFlags == unsignedOnly || i.signFlags == both)
       copyCR0toCR1(a, rAsm);
   }
   void emit(const incw& i) {
     a.addo(Reg64(i.d), Reg64(i.s), rone(), true);
-    if (i.needUnsigned)
+    if (i.signFlags == unsignedOnly || i.signFlags == both)
       copyCR0toCR1(a, rAsm);
   }
   void emit(const jmpi& i) { a.branchAuto(i.target); }
@@ -290,51 +290,51 @@ struct Vgen {
   void emit(const mulsd& i) { a.fmul(i.d, i.s1, i.s0); }
   void emit(const neg& i) {
     a.neg(i.d, i.s, true);
-    if (i.needUnsigned)
+    if (i.signFlags == unsignedOnly || i.signFlags == both)
       copyCR0toCR1(a, rAsm);
   }
   void emit(const nop& i) { a.nop(); } // no-op form
   void emit(const not& i) { a.nor(i.d, i.s, i.s, false); }
   void emit(const orq& i) {
     a.or(i.d, i.s0, i.s1, true);
-    if (i.needUnsigned)
+    if (i.signFlags == unsignedOnly || i.signFlags == both)
       copyCR0toCR1(a, rAsm);
   }
   void emit(const ret& i) { a.blr(); }
   void emit(const roundsd& i) { a.xsrdpi(i.d, i.s); }
   void emit(const sar& i) {
     a.srad(i.d, i.s1, i.s0, true);
-    if (i.needUnsigned)
+    if (i.signFlags == unsignedOnly || i.signFlags == both)
       copyCR0toCR1(a,rAsm);
   }
   void emit(const sarqi& i) {
     a.sradi(i.d, i.s1, i.s0.b(), true);
-    if (i.needUnsigned)
+    if (i.signFlags == unsignedOnly || i.signFlags == both)
       copyCR0toCR1(a, rAsm);
   }
   void emit(const shl& i) {
     a.sld(i.d, i.s1, i.s0, true);
-    if (i.needUnsigned)
+    if (i.signFlags == unsignedOnly || i.signFlags == both)
       copyCR0toCR1(a, rAsm);
   }
   void emit(const shlli& i) {
     a.slwi(Reg64(i.d), Reg64(i.s1), i.s0.b(), true);
-    if (i.needUnsigned)
+    if (i.signFlags == unsignedOnly || i.signFlags == both)
       copyCR0toCR1(a, rAsm);
   }
   void emit(const shlqi& i) {
     a.sldi(i.d, i.s1, i.s0.b(), true);
-    if (i.needUnsigned)
+    if (i.signFlags == unsignedOnly || i.signFlags == both)
       copyCR0toCR1(a, rAsm);
   }
   void emit(const shrli& i) {
     a.srwi(Reg64(i.d), Reg64(i.s1), i.s0.b(), true);
-    if (i.needUnsigned)
+    if (i.signFlags == unsignedOnly || i.signFlags == both)
       copyCR0toCR1(a, rAsm);
   }
   void emit(const shrqi& i) {
     a.srdi(i.d, i.s1, i.s0.b(), true);
-    if (i.needUnsigned)
+    if (i.signFlags == unsignedOnly || i.signFlags == both)
       copyCR0toCR1(a, rAsm);
   }
   void emit(const sqrtsd& i) { a.xssqrtdp(i.d,i.s); }
@@ -361,24 +361,24 @@ struct Vgen {
   // Subtractions: d = s1 - s0
   void emit(const subq& i) {
     a.subfo(i.d, i.s0, i.s1, true);
-    if (i.needUnsigned)
+    if (i.signFlags == unsignedOnly || i.signFlags == both)
       copyCR0toCR1(a, rAsm);
   }
   void emit(const subsd& i) { a.fsub(i.d, i.s1, i.s0, false); }
   void emit(const ud2& i) { a.trap(); }
   void emit(const xorb& i) {
     a.xor(Reg64(i.d), Reg64(i.s0), Reg64(i.s1), true);
-    if (i.needUnsigned)
+    if (i.signFlags == unsignedOnly || i.signFlags == both)
       copyCR0toCR1(a, rAsm);
   }
   void emit(const xorl& i) {
     a.xor(Reg64(i.d), Reg64(i.s0), Reg64(i.s1), true);
-    if (i.needUnsigned)
+    if (i.signFlags == unsignedOnly || i.signFlags == both)
       copyCR0toCR1(a, rAsm);
   }
   void emit(const xorq& i) {
     a.xor(i.d, i.s0, i.s1, true);
-    if (i.needUnsigned)
+    if (i.signFlags == unsignedOnly || i.signFlags == both)
       copyCR0toCR1(a, rAsm);
   }
   void emit(const xscvdpsxds& i) { a.xscvdpsxds(i.d, i.s); }
@@ -408,7 +408,7 @@ struct Vgen {
   void emit(const orqi& i) {
     a.li64(rAsm, i.s0.l());
     a.or(i.d, i.s1, rAsm, true /** or. implies Rc = 1 **/);
-    if (i.needUnsigned)
+    if (i.signFlags == unsignedOnly || i.signFlags == both)
       copyCR0toCR1(a, rAsm);
   }
   // macro for commonlizing X-/D-form of load/store instructions
@@ -450,18 +450,19 @@ struct Vgen {
     // https://goo.gl/F1wrbO
     if (i.s0 != i.s1) {
       a.and(rAsm, i.s0, i.s1, true);   // result is not used, only flags
-      if (i.needUnsigned)
+      if (i.signFlags == unsignedOnly || i.signFlags == both)
         copyCR0toCR1(a, rAsm);
     } else {
-      a.cmpdi(i.s0, Immed(0));
-      if (i.needUnsigned)
+      if (i.signFlags == signedOnly || i.signFlags == both)
+	a.cmpdi(i.s0, Immed(0));
+      if (i.signFlags == unsignedOnly || i.signFlags == both)
         a.cmpldi(i.s0, Immed(0), Assembler::CR::CR1);
     }
   }
   void emit(const xorqi& i) {
     a.li64(rAsm, i.s0.l());
     a.xor(i.d, i.s1, rAsm, true /** xor. implies Rc = 1 **/);
-    if (i.needUnsigned)
+    if (i.signFlags == unsignedOnly || i.signFlags == both)
       copyCR0toCR1(a, rAsm);
   }
 
@@ -1681,69 +1682,31 @@ void fixVptrsForPPC64(Vunit& unit) {
 
 #include "hphp/util/logger.h"
 
-bool needsUnsigned(const ConditionCode cc) {
-  bool ret = false;
+Signs signNeeds(const ConditionCode cc) {
+  Signs ret = neither;
   switch (cc) {
   case HPHP::jit::CC_O:
-    Logger::Verbose("BranchConditions::Overflow");
-    break;
   case HPHP::jit::CC_NO:
-    Logger::Verbose("BranchConditions::NoOverflow");
-    break;
-  case HPHP::jit::CC_B:
-    Logger::Verbose("BranchConditions::LessThan_Unsigned");
-    ret = true;
-    break;
-  case HPHP::jit::CC_AE:
-    Logger::Verbose("BranchConditions::GreaterThanEqual_Unsigned");
-    ret = true;
-    break;
   case HPHP::jit::CC_E:
-    Logger::Verbose("BranchConditions::Equal");
-    break;
   case HPHP::jit::CC_NE:
-    Logger::Verbose("BranchConditions::NotEqual");
-    break;
-  case HPHP::jit::CC_BE:
-    Logger::Verbose("BranchConditions::LessThanEqual_Unsigned");
-    ret = true;
-    break;
-  case HPHP::jit::CC_A:
-    Logger::Verbose("BranchConditions::GreaterThan_Unsigned");
-    ret = true;
-    break;
   case HPHP::jit::CC_S:
-    Logger::Verbose("BranchConditions::LessThan");
-    break;
   case HPHP::jit::CC_NS:
-    Logger::Verbose("BranchConditions::GreaterThan");
-    break;
-    
-    /*
-     * Parity works only for unordered double comparison
-     * Todo: fixed point comparison parity
-     * http://stackoverflow.com/q/32319673/5013070
-     */
   case HPHP::jit::CC_P:
-    Logger::Verbose("BranchConditions::Overflow");
-    break;
   case HPHP::jit::CC_NP:
-    Logger::Verbose("BranchConditions::NoOverflow");
-    break;
-    
   case HPHP::jit::CC_L:
-    Logger::Verbose("BranchConditions::LessThan");
-    break;
   case HPHP::jit::CC_NL:
-    Logger::Verbose("BranchConditions::GreaterThanEqual");
-    break;
   case HPHP::jit::CC_NG:
-    Logger::Verbose("BranchConditions::LessThanEqual");
-    break;
   case HPHP::jit::CC_G:
-    Logger::Verbose("BranchConditions::GreaterThan");
+    ret = signedOnly;
     break;
-    
+
+  case HPHP::jit::CC_B:
+  case HPHP::jit::CC_AE:
+  case HPHP::jit::CC_BE:
+  case HPHP::jit::CC_A:
+    ret = unsignedOnly;
+    break;
+
   default:
     not_implemented();
     break;
@@ -1751,14 +1714,36 @@ bool needsUnsigned(const ConditionCode cc) {
   return ret;
 }
 
-#define extractCC(name)					    \
-    case Vinstr::name:					    \
-      blockNeedsUnsigned |= needsUnsigned(inst.name##_.cc); \
-      break						    \
+static inline Signs addSigns(Signs a, Signs b) {
+  if (a==both || b==both) {
+    return both;
+  } else if (a == neither) {
+    return b;
+  } else if (b == neither) {
+    return a;
+  } else if (a == signedOnly) { // by now, a, b are either signed or unsigned
+    if (b != signedOnly) {
+      return both;
+    }
+    return signedOnly;
+  } else if (a == unsignedOnly) {
+    if (b != unsignedOnly)
+      return both;
+    return unsignedOnly;
+  }
+  always_assert(false);
+  return both;
+}
+    
+#define extractCC(name)					  \
+    case Vinstr::name:					  \
+      blockSigns = addSigns(blockSigns,			  \
+			    signNeeds(inst.name##_.cc));  \
+      break						  \
 
-#define updateNeedUnsigned(name)		      \
-    case Vinstr::name:				      \
-      inst.name##_.needUnsigned = blockNeedsUnsigned; \
+#define updateSignFlags(name)		   \
+    case Vinstr::name:			   \
+      inst.name##_.signFlags = blockSigns; \
       break
     
 void learnConditions(Vunit& unit) {
@@ -1767,7 +1752,7 @@ void learnConditions(Vunit& unit) {
   for (auto blockIt = blocks.begin(); blockIt != blocks.end(); blockIt++) {
     auto b = *blockIt;
     auto& block = unit.blocks[b];
-    bool blockNeedsUnsigned = false;
+    Signs blockSigns = neither;
     for (auto i = block.code.begin(); i != block.code.end(); i++) {
       auto& inst = *i;
       switch (inst.op) {
@@ -1789,36 +1774,36 @@ void learnConditions(Vunit& unit) {
     for (auto i = block.code.begin(); i != block.code.end(); i++) {
       auto& inst = *i;
       switch (inst.op) {
-      updateNeedUnsigned(addl);
-      updateNeedUnsigned(addq);
-      updateNeedUnsigned(andq);
-      updateNeedUnsigned(andqi);
-      updateNeedUnsigned(decl);
-      updateNeedUnsigned(decq);
-      updateNeedUnsigned(incw);
-      updateNeedUnsigned(incl);
-      updateNeedUnsigned(incq);
-      updateNeedUnsigned(imul);
-      updateNeedUnsigned(neg);
-      updateNeedUnsigned(orq);
-      updateNeedUnsigned(orqi);
-      updateNeedUnsigned(sar);
-      updateNeedUnsigned(shl);
-      updateNeedUnsigned(sarqi);
-      updateNeedUnsigned(shlli);
-      updateNeedUnsigned(shlqi);
-      updateNeedUnsigned(shrli);
-      updateNeedUnsigned(shrqi);
-      updateNeedUnsigned(subq);
-      updateNeedUnsigned(xorb);
-      updateNeedUnsigned(xorl);
-      updateNeedUnsigned(xorq);
-      updateNeedUnsigned(xorqi);
-      updateNeedUnsigned(testq);
-      updateNeedUnsigned(cmpl);
-      updateNeedUnsigned(cmpli);
-      updateNeedUnsigned(cmpq);
-      updateNeedUnsigned(cmpqi);
+      updateSignFlags(addl);
+      updateSignFlags(addq);
+      updateSignFlags(andq);
+      updateSignFlags(andqi);
+      updateSignFlags(decl);
+      updateSignFlags(decq);
+      updateSignFlags(incw);
+      updateSignFlags(incl);
+      updateSignFlags(incq);
+      updateSignFlags(imul);
+      updateSignFlags(neg);
+      updateSignFlags(orq);
+      updateSignFlags(orqi);
+      updateSignFlags(sar);
+      updateSignFlags(shl);
+      updateSignFlags(sarqi);
+      updateSignFlags(shlli);
+      updateSignFlags(shlqi);
+      updateSignFlags(shrli);
+      updateSignFlags(shrqi);
+      updateSignFlags(subq);
+      updateSignFlags(xorb);
+      updateSignFlags(xorl);
+      updateSignFlags(xorq);
+      updateSignFlags(xorqi);
+      updateSignFlags(testq);
+      updateSignFlags(cmpl);
+      updateSignFlags(cmpli);
+      updateSignFlags(cmpq);
+      updateSignFlags(cmpqi);
       default:
         break;
       }

--- a/hphp/runtime/vm/jit/vasm-ppc64.cpp
+++ b/hphp/runtime/vm/jit/vasm-ppc64.cpp
@@ -154,7 +154,8 @@ struct Vgen {
   }
   void emit(const addl& i) {
     a.addo(Reg64(i.d), Reg64(i.s1), Reg64(i.s0), true);
-    copyCR0toCR1(a, rAsm);
+    if (i.needUnsigned)
+      copyCR0toCR1(a, rAsm);
   }
   void emit(const ldimmqs& i) {
     emitSmashableMovq(a.code(), env.meta, i.s.q(), i.d);
@@ -168,40 +169,53 @@ struct Vgen {
   // instructions
   void emit(const addq& i) {
     a.addo(i.d, i.s0, i.s1, true);
-    copyCR0toCR1(a, rAsm);
+    if (i.needUnsigned) {
+      Logger::Verbose("addq emitting cr0-1");
+      copyCR0toCR1(a, rAsm);
+    } else {
+      Logger::Verbose("addq not emitting cr0-1");
+    }
   }
   void emit(const addsd& i) { a.fadd(i.d, i.s0, i.s1); }
   void emit(const andq& i) {
     a.and(i.d, i.s0, i.s1, true);
-    copyCR0toCR1(a, rAsm);
+    if (i.needUnsigned)
+      copyCR0toCR1(a, rAsm);
   }
   void emit(const andqi& i) {
     a.andi(i.d, i.s1, i.s0);
-    copyCR0toCR1(a, rAsm);
+    if (i.needUnsigned)
+      copyCR0toCR1(a, rAsm);
   } // andi changes CR0
   void emit(const cmpl& i) {
     a.cmpw(Reg64(i.s1), Reg64(i.s0));
-    a.cmplw(Reg64(i.s1), Reg64(i.s0), Assembler::CR::CR1);
+    if (i.needUnsigned)
+      a.cmplw(Reg64(i.s1), Reg64(i.s0), Assembler::CR::CR1);
   }
   void emit(const cmpli& i) {
     a.cmpwi(Reg64(i.s1), i.s0);
-    a.cmplwi(Reg64(i.s1), i.s0, Assembler::CR::CR1);
+    if (i.needUnsigned)
+      a.cmplwi(Reg64(i.s1), i.s0, Assembler::CR::CR1);
   }
   void emit(const cmpq& i) {
     a.cmpd(i.s1, i.s0);
-    a.cmpld(i.s1, i.s0, Assembler::CR::CR1);
+    if (i.needUnsigned)
+      a.cmpld(i.s1, i.s0, Assembler::CR::CR1);
   }
   void emit(const cmpqi& i) {
     a.cmpdi(i.s1, i.s0);
-    a.cmpldi(i.s1, i.s0, Assembler::CR::CR1);
+    if (i.needUnsigned)
+      a.cmpldi(i.s1, i.s0, Assembler::CR::CR1);
   }
   void emit(const decl& i) {
     a.subfo(Reg64(i.d), rone(), Reg64(i.s), true);
-    copyCR0toCR1(a, rAsm);
+    if (i.needUnsigned)
+      copyCR0toCR1(a, rAsm);
   }
   void emit(const decq& i) {
     a.subfo(i.d, rone(), i.s, true);
-    copyCR0toCR1(a, rAsm);
+    if (i.needUnsigned)
+      copyCR0toCR1(a, rAsm);
   }
   void emit(const divint& i) { a.divd(i.d,  i.s0, i.s1, false); }
   void emit(const divsd& i) { a.fdiv(i.d, i.s1, i.s0); }
@@ -224,19 +238,23 @@ struct Vgen {
   }
   void emit(const imul& i) {
     a.mulldo(i.d, i.s1, i.s0, true);
-    copyCR0toCR1(a, rAsm);
+    if (i.needUnsigned)
+      copyCR0toCR1(a, rAsm);
   }
   void emit(const incl& i) {
     a.addo(Reg64(i.d), Reg64(i.s), rone(), true);
-    copyCR0toCR1(a, rAsm);
+    if (i.needUnsigned)
+      copyCR0toCR1(a, rAsm);
   }
   void emit(const incq& i) {
     a.addo(i.d, i.s, rone(), true);
-    copyCR0toCR1(a, rAsm);
+    if (i.needUnsigned)
+      copyCR0toCR1(a, rAsm);
   }
   void emit(const incw& i) {
     a.addo(Reg64(i.d), Reg64(i.s), rone(), true);
-    copyCR0toCR1(a, rAsm);
+    if (i.needUnsigned)
+      copyCR0toCR1(a, rAsm);
   }
   void emit(const jmpi& i) { a.branchAuto(i.target); }
   void emit(const landingpad&) { }
@@ -272,43 +290,52 @@ struct Vgen {
   void emit(const mulsd& i) { a.fmul(i.d, i.s1, i.s0); }
   void emit(const neg& i) {
     a.neg(i.d, i.s, true);
-    copyCR0toCR1(a, rAsm);
+    if (i.needUnsigned)
+      copyCR0toCR1(a, rAsm);
   }
   void emit(const nop& i) { a.nop(); } // no-op form
   void emit(const not& i) { a.nor(i.d, i.s, i.s, false); }
   void emit(const orq& i) {
     a.or(i.d, i.s0, i.s1, true);
-    copyCR0toCR1(a, rAsm);
+    if (i.needUnsigned)
+      copyCR0toCR1(a, rAsm);
   }
   void emit(const ret& i) { a.blr(); }
   void emit(const roundsd& i) { a.xsrdpi(i.d, i.s); }
   void emit(const sar& i) {
     a.srad(i.d, i.s1, i.s0, true);
-    copyCR0toCR1(a,rAsm);
+    if (i.needUnsigned)
+      copyCR0toCR1(a,rAsm);
   }
   void emit(const sarqi& i) {
     a.sradi(i.d, i.s1, i.s0.b(), true);
-    copyCR0toCR1(a, rAsm);
+    if (i.needUnsigned)
+      copyCR0toCR1(a, rAsm);
   }
   void emit(const shl& i) {
     a.sld(i.d, i.s1, i.s0, true);
-    copyCR0toCR1(a, rAsm);
+    if (i.needUnsigned)
+      copyCR0toCR1(a, rAsm);
   }
   void emit(const shlli& i) {
     a.slwi(Reg64(i.d), Reg64(i.s1), i.s0.b(), true);
-    copyCR0toCR1(a, rAsm);
+    if (i.needUnsigned)
+      copyCR0toCR1(a, rAsm);
   }
   void emit(const shlqi& i) {
     a.sldi(i.d, i.s1, i.s0.b(), true);
-    copyCR0toCR1(a, rAsm);
+    if (i.needUnsigned)
+      copyCR0toCR1(a, rAsm);
   }
   void emit(const shrli& i) {
     a.srwi(Reg64(i.d), Reg64(i.s1), i.s0.b(), true);
-    copyCR0toCR1(a, rAsm);
+    if (i.needUnsigned)
+      copyCR0toCR1(a, rAsm);
   }
   void emit(const shrqi& i) {
     a.srdi(i.d, i.s1, i.s0.b(), true);
-    copyCR0toCR1(a, rAsm);
+    if (i.needUnsigned)
+      copyCR0toCR1(a, rAsm);
   }
   void emit(const sqrtsd& i) { a.xssqrtdp(i.d,i.s); }
   void emit(const stdcx& i) { a.stdcx(i.s, i.d); }
@@ -334,21 +361,25 @@ struct Vgen {
   // Subtractions: d = s1 - s0
   void emit(const subq& i) {
     a.subfo(i.d, i.s0, i.s1, true);
-    copyCR0toCR1(a, rAsm);
+    if (i.needUnsigned)
+      copyCR0toCR1(a, rAsm);
   }
   void emit(const subsd& i) { a.fsub(i.d, i.s1, i.s0, false); }
   void emit(const ud2& i) { a.trap(); }
   void emit(const xorb& i) {
     a.xor(Reg64(i.d), Reg64(i.s0), Reg64(i.s1), true);
-    copyCR0toCR1(a, rAsm);
+    if (i.needUnsigned)
+      copyCR0toCR1(a, rAsm);
   }
   void emit(const xorl& i) {
     a.xor(Reg64(i.d), Reg64(i.s0), Reg64(i.s1), true);
-    copyCR0toCR1(a, rAsm);
+    if (i.needUnsigned)
+      copyCR0toCR1(a, rAsm);
   }
   void emit(const xorq& i) {
     a.xor(i.d, i.s0, i.s1, true);
-    copyCR0toCR1(a, rAsm);
+    if (i.needUnsigned)
+      copyCR0toCR1(a, rAsm);
   }
   void emit(const xscvdpsxds& i) { a.xscvdpsxds(i.d, i.s); }
   void emit(const xscvsxddp& i) { a.xscvsxddp(i.d, i.s); }
@@ -377,7 +408,8 @@ struct Vgen {
   void emit(const orqi& i) {
     a.li64(rAsm, i.s0.l());
     a.or(i.d, i.s1, rAsm, true /** or. implies Rc = 1 **/);
-    copyCR0toCR1(a, rAsm);
+    if (i.needUnsigned)
+      copyCR0toCR1(a, rAsm);
   }
   // macro for commonlizing X-/D-form of load/store instructions
 #define X(instr, dst, ptr)                                \
@@ -418,16 +450,19 @@ struct Vgen {
     // https://goo.gl/F1wrbO
     if (i.s0 != i.s1) {
       a.and(rAsm, i.s0, i.s1, true);   // result is not used, only flags
-      copyCR0toCR1(a, rAsm);
+      if (i.needUnsigned)
+        copyCR0toCR1(a, rAsm);
     } else {
       a.cmpdi(i.s0, Immed(0));
-      a.cmpldi(i.s0, Immed(0), Assembler::CR::CR1);
+      if (i.needUnsigned)
+        a.cmpldi(i.s0, Immed(0), Assembler::CR::CR1);
     }
   }
   void emit(const xorqi& i) {
     a.li64(rAsm, i.s0.l());
     a.xor(i.d, i.s1, rAsm, true /** xor. implies Rc = 1 **/);
-    copyCR0toCR1(a, rAsm);
+    if (i.needUnsigned)
+      copyCR0toCR1(a, rAsm);
   }
 
   void emit(const conjure& i) { always_assert(false); }
@@ -1644,6 +1679,154 @@ void fixVptrsForPPC64(Vunit& unit) {
 ///////////////////////////////////////////////////////////////////////////////
 } // anonymous namespace
 
+#include "hphp/util/logger.h"
+
+bool needsUnsigned(const ConditionCode cc) {
+  bool ret = false;
+  switch (cc) {
+  case HPHP::jit::CC_O:
+    Logger::Verbose("BranchConditions::Overflow");
+    break;
+  case HPHP::jit::CC_NO:
+    Logger::Verbose("BranchConditions::NoOverflow");
+    break;
+  case HPHP::jit::CC_B:
+    Logger::Verbose("BranchConditions::LessThan_Unsigned");
+    ret = true;
+    break;
+  case HPHP::jit::CC_AE:
+    Logger::Verbose("BranchConditions::GreaterThanEqual_Unsigned");
+    ret = true;
+    break;
+  case HPHP::jit::CC_E:
+    Logger::Verbose("BranchConditions::Equal");
+    break;
+  case HPHP::jit::CC_NE:
+    Logger::Verbose("BranchConditions::NotEqual");
+    break;
+  case HPHP::jit::CC_BE:
+    Logger::Verbose("BranchConditions::LessThanEqual_Unsigned");
+    ret = true;
+    break;
+  case HPHP::jit::CC_A:
+    Logger::Verbose("BranchConditions::GreaterThan_Unsigned");
+    ret = true;
+    break;
+  case HPHP::jit::CC_S:
+    Logger::Verbose("BranchConditions::LessThan");
+    break;
+  case HPHP::jit::CC_NS:
+    Logger::Verbose("BranchConditions::GreaterThan");
+    break;
+    
+    /*
+     * Parity works only for unordered double comparison
+     * Todo: fixed point comparison parity
+     * http://stackoverflow.com/q/32319673/5013070
+     */
+  case HPHP::jit::CC_P:
+    Logger::Verbose("BranchConditions::Overflow");
+    break;
+  case HPHP::jit::CC_NP:
+    Logger::Verbose("BranchConditions::NoOverflow");
+    break;
+    
+  case HPHP::jit::CC_L:
+    Logger::Verbose("BranchConditions::LessThan");
+    break;
+  case HPHP::jit::CC_NL:
+    Logger::Verbose("BranchConditions::GreaterThanEqual");
+    break;
+  case HPHP::jit::CC_NG:
+    Logger::Verbose("BranchConditions::LessThanEqual");
+    break;
+  case HPHP::jit::CC_G:
+    Logger::Verbose("BranchConditions::GreaterThan");
+    break;
+    
+  default:
+    not_implemented();
+    break;
+  }
+  return ret;
+}
+
+#define extractCC(name)					    \
+    case Vinstr::name:					    \
+      blockNeedsUnsigned |= needsUnsigned(inst.name##_.cc); \
+      break						    \
+
+#define updateNeedUnsigned(name)		      \
+    case Vinstr::name:				      \
+      inst.name##_.needUnsigned = blockNeedsUnsigned; \
+      break
+    
+void learnConditions(Vunit& unit) {
+  auto blocks = sortBlocks(unit);
+
+  for (auto blockIt = blocks.begin(); blockIt != blocks.end(); blockIt++) {
+    auto b = *blockIt;
+    auto& block = unit.blocks[b];
+    bool blockNeedsUnsigned = false;
+    for (auto i = block.code.begin(); i != block.code.end(); i++) {
+      auto& inst = *i;
+      switch (inst.op) {
+      extractCC(jcc);
+      extractCC(jcci);
+      extractCC(bindjcc);
+      extractCC(fallbackcc);
+      extractCC(phijcc);
+      extractCC(cloadq);
+      extractCC(cmovb);
+      extractCC(cmovw);
+      extractCC(cmovl);
+      extractCC(cmovq);
+      extractCC(setcc);
+      default:
+	break;
+      }
+    }
+    for (auto i = block.code.begin(); i != block.code.end(); i++) {
+      auto& inst = *i;
+      switch (inst.op) {
+      updateNeedUnsigned(addl);
+      updateNeedUnsigned(addq);
+      updateNeedUnsigned(andq);
+      updateNeedUnsigned(andqi);
+      updateNeedUnsigned(decl);
+      updateNeedUnsigned(decq);
+      updateNeedUnsigned(incw);
+      updateNeedUnsigned(incl);
+      updateNeedUnsigned(incq);
+      updateNeedUnsigned(imul);
+      updateNeedUnsigned(neg);
+      updateNeedUnsigned(orq);
+      updateNeedUnsigned(orqi);
+      updateNeedUnsigned(sar);
+      updateNeedUnsigned(shl);
+      updateNeedUnsigned(sarqi);
+      updateNeedUnsigned(shlli);
+      updateNeedUnsigned(shlqi);
+      updateNeedUnsigned(shrli);
+      updateNeedUnsigned(shrqi);
+      updateNeedUnsigned(subq);
+      updateNeedUnsigned(xorb);
+      updateNeedUnsigned(xorl);
+      updateNeedUnsigned(xorq);
+      updateNeedUnsigned(xorqi);
+      updateNeedUnsigned(testq);
+      updateNeedUnsigned(cmpl);
+      updateNeedUnsigned(cmpli);
+      updateNeedUnsigned(cmpq);
+      updateNeedUnsigned(cmpqi);
+      default:
+        break;
+      }
+    }
+  }
+}
+
+    
 void optimizePPC64(Vunit& unit, const Abi& abi, bool regalloc) {
   Timer timer(Timer::vasm_optimize);
 
@@ -1667,6 +1850,8 @@ void optimizePPC64(Vunit& unit, const Abi& abi, bool regalloc) {
   if (unit.blocks.size() > 1) {
     optimizeJmps(unit);
   }
+
+  learnConditions(unit);
 }
 
 void emitPPC64(const Vunit& unit, Vtext& text, CGMeta& fixups,


### PR DESCRIPTION
This PR contains some draft patches that improve performance of generated code (and one small optimisation of the core). Each patch has a comprehensive description of what it does.

In short, the preparation for unsigned comparisons meant that every comparison was done twice, and that there was a move from and move to CR for each arithmetic operation that set flags. This add an optimisation pass that looks forwards to what branches are required, then only emits the comparison/copy operations when required.

The improvements are pretty good: ~9% for MediaWiki and 26% for a microbenchmark.

However, the changes are quite intrusive, and affect 'generic' vasm code. So there is probably a much better way to get the same result, and I'm hoping you guys have some ideas. (Or if you think FB would take it regardless of the mess, that would also be good to know!)
