### PR TITLE
Testing - Port tc-print functions to PPC64

### DIFF
--- a/hphp/tools/tc-print/CMakeLists.txt
+++ b/hphp/tools/tc-print/CMakeLists.txt
@@ -10,4 +10,14 @@ if (LibXed_INCLUDE_DIR AND LibXed_LIBRARY)
   target_link_libraries(tc-print ${HHVM_LINK_LIBRARIES})
   embed_all_systemlibs(tc-print "${CMAKE_CURRENT_BINARY_DIR}/../.."
                                 "${CMAKE_CURRENT_BINARY_DIR}/tc-print")
+elseif(IS_PPC64)
+  add_executable(tc-print "mappers.cpp" "offline-trans-data.cpp"
+                          "offline-x86-code.cpp"  "perf-events.cpp"
+                          "repo-wrapper.cpp"  "tc-print.cpp"
+                          "../../hhvm/global-variables.cpp"
+                          "../../hhvm/process-init.cpp")
+  link_object_libraries(tc-print ${HHVM_WHOLE_ARCHIVE_LIBRARIES})
+  target_link_libraries(tc-print ${HHVM_LINK_LIBRARIES})
+  embed_all_systemlibs(tc-print "${CMAKE_CURRENT_BINARY_DIR}/../.."
+                                "${CMAKE_CURRENT_BINARY_DIR}/tc-print")
 endif()

--- a/hphp/tools/tc-print/offline-x86-code.cpp
+++ b/hphp/tools/tc-print/offline-x86-code.cpp
@@ -90,10 +90,12 @@ TCRegion OfflineX86Code::findTCRegionContaining(TCA addr) const {
 }
 
 void OfflineX86Code::xedInit() {
+#ifdef __x86_64__
   xed_state_init(&xed_state, XED_MACHINE_MODE_LONG_64,
                  XED_ADDRESS_WIDTH_64b, XED_ADDRESS_WIDTH_64b);
   xed_tables_init();
   xed_syntax = getenv("HHVM_INTEL_DISAS") ? XED_SYNTAX_INTEL : XED_SYNTAX_ATT;
+#endif
 }
 
 
@@ -124,7 +126,7 @@ TCA OfflineX86Code::getTransJmpTargets(const TransRec *transRec,
 
   return aFallThru;
 }
-
+#ifdef __x86_64__
 TCA OfflineX86Code::collectJmpTargets(FILE  *file,
                                       TCA    fileStartAddr,
                                       TCA    codeStartAddr,
@@ -189,14 +191,6 @@ TCA OfflineX86Code::collectJmpTargets(FILE  *file,
     return ip;
   }
   return 0;
-}
-
-void OfflineX86Code::printDisasm(TCA startAddr, uint32_t len,
-                                 const vector<TransBCMapping>& bcMap,
-                                 const PerfEventsMap<TCA>& perfEvents) {
-  TCRegion tcr = findTCRegionContaining(startAddr);
-  disasm(tcRegions[tcr].file, tcRegions[tcr].baseAddr, startAddr, len,
-         perfEvents, BCMappingInfo(tcr, bcMap));
 }
 
 // Disassemble the code from the given raw file, whose initial address is given
@@ -324,6 +318,92 @@ void OfflineX86Code::disasm(FILE* file,
     frontier += instrLen;
     ip       += instrLen;
   }
+}
+#elif defined(__powerpc64__)
+static constexpr auto kIndent = 4;
+
+TCA OfflineX86Code::collectJmpTargets(FILE  *file,
+                                      TCA    fileStartAddr,
+                                      TCA    codeStartAddr,
+                                      uint64_t codeLen,
+                                      vector<TCA> *jmpTargets) {
+
+  return 0;
+}
+
+// Disassemble the code from the given raw file, whose initial address is given
+// by fileStartAddr, for the address range given by
+// [codeStartAddr, codeStartAddr + codeLen)
+
+void OfflineX86Code::disasm(FILE* file,
+                            TCA   fileStartAddr,
+                            TCA   codeStartAddr,
+                            uint64_t codeLen,
+                            const PerfEventsMap<TCA>& perfEvents,
+                            BCMappingInfo bcMappingInfo,
+                            bool printAddr /* =true */,
+                            bool printBinary /* =false */) {
+
+  //char codeStr[MAX_INSTR_ASM_LEN];
+  uint8_t* code = (uint8_t*) alloca(codeLen);
+  uint8_t* frontier;
+  uint32_t instrLen = 4;
+  TCA          ip;
+  size_t       currBC = 0;
+
+  if (codeLen == 0) return;
+
+  if (fseek(file, codeStartAddr - fileStartAddr, SEEK_SET)) {
+    error("disasm error: seeking file");
+  }
+
+  size_t readLen = fread(code, codeLen, 1, file);
+  if (readLen != 1) error("disasm error: reading file");
+
+  // Decode and print each instruction
+  for (frontier = code, ip = codeStartAddr; frontier < code + codeLen; ) {
+    std::ostringstream codeStr;
+    ppc64_asm::Disassembler disasm(false, false, kIndent + 4,
+                                   color(ANSI_COLOR_BROWN));
+    disasm.disassembly(codeStr, frontier);
+
+    // Annotate the x86 with its bytecode.
+    currBC = printBCMapping(bcMappingInfo, currBC, (TCA)ip);
+
+    if (printAddr) printf("%14p: ", ip);
+
+    if (printBinary) {
+      uint32_t i;
+      for (i=0; i < instrLen; i++) {
+        printf("%02X", frontier[i]);
+      }
+      for (; i < 16; i++) {
+        printf("  ");
+      }
+    }
+
+    if (!perfEvents.empty()) {
+      printEventStats((TCA)ip, instrLen, perfEvents);
+    } else {
+      printf("%48s", "");
+    }
+
+    const std::string tmp = codeStr.str();
+    const char* cstr = tmp.c_str();
+    printf("%s", cstr);
+
+    frontier += instrLen;
+    ip       += instrLen;
+  }
+}
+#endif
+
+void OfflineX86Code::printDisasm(TCA startAddr, uint32_t len,
+                                 const vector<TransBCMapping>& bcMap,
+                                 const PerfEventsMap<TCA>& perfEvents) {
+  TCRegion tcr = findTCRegionContaining(startAddr);
+  disasm(tcRegions[tcr].file, tcRegions[tcr].baseAddr, startAddr, len,
+         perfEvents, BCMappingInfo(tcr, bcMap));
 }
 
 void OfflineX86Code::loadSymbolsMap() {

--- a/hphp/tools/tc-print/offline-x86-code.h
+++ b/hphp/tools/tc-print/offline-x86-code.h
@@ -20,15 +20,20 @@
 #include <string>
 #include <unordered_map>
 
+#include "hphp/ppc64-asm/asm-ppc64.h"
+#include "hphp/ppc64-asm/dasm-ppc64.h"
+
 #include "hphp/runtime/vm/unit.h"
 #include "hphp/runtime/vm/jit/translator.h"
 
 #include "hphp/tools/tc-print/offline-trans-data.h"
 #include "hphp/tools/tc-print/perf-events.h"
 
+#ifdef __x86_64__
 extern "C" {
 #include <xed-interface.h>
 }
+#endif
 
 namespace HPHP { namespace jit {
 
@@ -99,8 +104,11 @@ private:
 
   std::string       dumpDir;
   TCRegionRec       tcRegions[TCRCount];
+
+#ifdef __x86_64__
   xed_state_t       xed_state;
   xed_syntax_enum_t xed_syntax;
+#endif
 
   std::unordered_map<TCA, std::string> addr2SymMap;
 


### PR DESCRIPTION
The tc-print only uses two functions with arch code specific, which were
ported to PPC64 using the internal Decoder.
This implementation is still not good to send to facebook, since the target
of the branchs are not being dispayed and we need to think in a better
architectural solution, since it's using static "if" to switch the code.